### PR TITLE
File downloader time range can be based on current UTC and parser arguments

### DIFF
--- a/src/Database/Statistics.php
+++ b/src/Database/Statistics.php
@@ -244,8 +244,11 @@ class Database_Statistics {
 		$distance = $endDate->getTimestamp() - $startDate->getTimestamp();
 		$interval = new DateInterval('PT'.$distance.'S');
 		
-		$startDate->modify('-'.$distance.' seconds');
-		$endDate->modify('+'.$distance.' seconds');
+		$startDateTimeline = clone $startDate;
+		$endDateTimeline = clone $endDate;
+		
+		$startDateTimeline->modify('-'.$distance.' seconds');
+		$endDateTimeline->modify('+'.$distance.' seconds');
 		
 		$dateStart = toMySQLDateString($startDate);
 		$dateEnd = toMySQLDateString($endDate);
@@ -277,7 +280,8 @@ class Database_Statistics {
 	            $sources[$layersCount]->name = (isset($layer['uiLabels'][0]['name']) ? $layer['uiLabels'][0]['name'] : '').' '.(isset($layer['uiLabels'][1]['name']) ? $layer['uiLabels'][1]['name'] : '').' '.(isset($layer['uiLabels'][2]['name']) ? $layer['uiLabels'][2]['name'] : '');
 	            $sources[$layersCount]->data = array();
 	            
-		        $sources[$layersCount]->data[] = array($startDate->getTimestamp()*1000, null);
+		        $sources[$layersCount]->data[] = array($startDateTimeline->getTimestamp()*1000, null);
+		        //$sources[$layersCount]->data[] = array($startDate->getTimestamp()*1000, null);
 	            
 	            $layersArray[] = $sourceId;
 	            $layersKeys[$sourceId] = $layersCount;
@@ -338,8 +342,6 @@ class Database_Statistics {
 		            throw new Exception($msg, 25);
 		    }
 			
-			//echo $sql."\n<br />";
-			
 			$result = $this->_dbConnection->query($sql);
 			
 			while ($row = $result->fetch_array(MYSQLI_ASSOC)) {
@@ -354,7 +356,8 @@ class Database_Statistics {
 	        }
 	        
 	        foreach($sources as $sourceId=>$row){
-		        $sources[$sourceId]->data[] = array($endDate->getTimestamp()*1000, null);
+		        //$sources[$sourceId]->data[] = array($endDate->getTimestamp()*1000, null);
+		        $sources[$sourceId]->data[] = array($endDateTimeline->getTimestamp()*1000, null);
 	        }
 	        
 	        return json_encode($sources);

--- a/src/Database/Statistics.php
+++ b/src/Database/Statistics.php
@@ -244,11 +244,8 @@ class Database_Statistics {
 		$distance = $endDate->getTimestamp() - $startDate->getTimestamp();
 		$interval = new DateInterval('PT'.$distance.'S');
 		
-		$startDateTimeline = clone $startDate;
-		$endDateTimeline = clone $endDate;
-		
-		$startDateTimeline->modify('-'.$distance.' seconds');
-		$endDateTimeline->modify('+'.$distance.' seconds');
+		$startDate->modify('-'.$distance.' seconds');
+		$endDate->modify('+'.$distance.' seconds');
 		
 		$dateStart = toMySQLDateString($startDate);
 		$dateEnd = toMySQLDateString($endDate);
@@ -280,8 +277,7 @@ class Database_Statistics {
 	            $sources[$layersCount]->name = (isset($layer['uiLabels'][0]['name']) ? $layer['uiLabels'][0]['name'] : '').' '.(isset($layer['uiLabels'][1]['name']) ? $layer['uiLabels'][1]['name'] : '').' '.(isset($layer['uiLabels'][2]['name']) ? $layer['uiLabels'][2]['name'] : '');
 	            $sources[$layersCount]->data = array();
 	            
-		        $sources[$layersCount]->data[] = array($startDateTimeline->getTimestamp()*1000, null);
-		        //$sources[$layersCount]->data[] = array($startDate->getTimestamp()*1000, null);
+		        $sources[$layersCount]->data[] = array($startDate->getTimestamp()*1000, null);
 	            
 	            $layersArray[] = $sourceId;
 	            $layersKeys[$sourceId] = $layersCount;
@@ -337,10 +333,11 @@ class Database_Statistics {
 					ORDER BY DATE(DATE_FORMAT(date, "%Y-01-01"));';
 		            break;
 		        default:
-		            $msg = 'Invalid resolution specified. Valid options include: '
-		                 . implode(', ', $validRes);
+		            $msg = 'Invalid resolution specified. Valid options include: ' . implode(', ', $validRes);
 		            throw new Exception($msg, 25);
 		    }
+			
+			//echo $sql."\n<br />";
 			
 			$result = $this->_dbConnection->query($sql);
 			
@@ -356,8 +353,7 @@ class Database_Statistics {
 	        }
 	        
 	        foreach($sources as $sourceId=>$row){
-		        //$sources[$sourceId]->data[] = array($endDate->getTimestamp()*1000, null);
-		        $sources[$sourceId]->data[] = array($endDateTimeline->getTimestamp()*1000, null);
+		        $sources[$sourceId]->data[] = array($endDate->getTimestamp()*1000, null);
 	        }
 	        
 	        return json_encode($sources);

--- a/src/Module/WebClient.php
+++ b/src/Module/WebClient.php
@@ -565,12 +565,19 @@ class Module_WebClient implements Module {
 		$endDate = gmstrftime('%Y-%m-%d %H:%M:%S', $end / 1000) - 60;
         
         // find the right range
-		// two days range loads minute data
-		if ($range < 2 * 24 * 3600 * 1000) {
+		if ($range < 90 * 60 * 1000) {
 			$resolution = 'm';
 			
+		// 12 hours range loads hourly data
+		} elseif  ($range < 12 * 3600 * 1000) {
+			$resolution = '5m';
+			
 		// one month range loads hourly data
-		} elseif ($range < 31 * 24 * 3600 * 1000) {
+		} elseif  ($range < 2 * 24 * 3600 * 1000) {
+			$resolution = '15m';
+			
+		// one month range loads hourly data
+		} elseif ($range < 20 * 24 * 3600 * 1000) {
 			$resolution = 'h';
 			
 		// one year range loads daily data

--- a/src/Module/WebClient.php
+++ b/src/Module/WebClient.php
@@ -565,7 +565,7 @@ class Module_WebClient implements Module {
 		$endDate = gmstrftime('%Y-%m-%d %H:%M:%S', $end / 1000) - 60;
         
         // find the right range
-		if ($range < 90 * 60 * 1000) {
+		if ($range < 105 * 60 * 1000) {
 			$resolution = 'm';
 			
 		// 12 hours range loads hourly data


### PR DESCRIPTION
This PR allows the jp2 file downloader to query for images in a time range calculated using the current UTC and some new parser arguments.  The argument '-f' or '--backfill' invokes this new capability.  For example, '-f 7 1' will cause the downloader to look for files in the range of the current time - seven days to current time - 1 day.  This is intended to be used with a cron job in order to do regular (for example, daily) and automatic searches in extended time-ranges looking for images that may have been missed due to server outages, pipeline issues, etc.