### PR TITLE
This is not a real pull request

### DIFF
--- a/install/helioviewer/jp2parser.py
+++ b/install/helioviewer/jp2parser.py
@@ -14,6 +14,8 @@ from sunpy.io.header import FileHeader
 from glymur import Jp2k
 from sunpy.util.xml import xml_to_dict
 
+from sources.EUI import EUIMap
+
 __HV_CONSTANT_RSUN__ = 959.644
 __HV_CONSTANT_AU__ = 149597870700
 

--- a/install/sources/EUI.py
+++ b/install/sources/EUI.py
@@ -1,0 +1,14 @@
+
+from sunpy.map import GenericMap
+
+class EUIMap(GenericMap):
+
+    def __init__(self, data, header, **kwargs):
+        GenericMap.__init__(self, data, header, **kwargs)
+
+        self.meta["detector"] = header.get("detector").split("_")[0]
+        self.meta["obsrvtry"] = "SOLO"
+
+    @classmethod
+    def is_datasource_for(cls, data, header, **kwargs):
+        return header.get("instrume") == "EUI"

--- a/src/Database/ImgIndex.php
+++ b/src/Database/ImgIndex.php
@@ -1350,12 +1350,13 @@ class Database_ImgIndex {
         }
 
         // Set defaults for verbose mode (JHelioviewer)
+        /* Some servers may not have AIA 171 data - better solution to be found
         if ($verbose) {
             $tree["SDO"]["default"]=true;
             $tree["SDO"]["children"]["AIA"]["default"]=true;
             $tree["SDO"]["children"]["AIA"]["children"]["171"]["default"]=true;
         }
-
+        */
         return $tree;
     }
 


### PR DESCRIPTION
Those are changes I had to make to enable a Helioviewer server at ESAC (https://www.esa.int/About_Us/ESAC). For the time being, it supports only the EUI instrument of Solar Orbiter.

The issue I want raise is that server unconditionally sets AIA 171 dataset as default even in case it has no AIA 171 images.