### PR TITLE
Fix kdu_expand errors by limiting maximum `-reduce` per file

### DIFF
--- a/src/Image/JPEG2000/JP2Image.php
+++ b/src/Image/JPEG2000/JP2Image.php
@@ -106,6 +106,9 @@ class Image_JPEG2000_JP2Image {
 			error_log($msg . " tmpfile is $tmpfile");
 			throw new Exception($msg, 14);
 		}
+		// Now that command was successful, delete the tmpfile
+		// Don't delete it earlier so we can debug in case something goes wrong.
+		unlink($tmpfile);
 
 		// The result from preg_match is the number of levels and cache the result.
         $this->_maxReduction = $matches[1];

--- a/src/Image/JPEG2000/JP2Image.php
+++ b/src/Image/JPEG2000/JP2Image.php
@@ -84,6 +84,7 @@ class Image_JPEG2000_JP2Image {
 	 */
 	public function getMaxReduction() {
         if ($this->_maxReduction) {
+            // return from cache. Else proceed.
             return $this->_maxReduction;
         }
 		// Create a tmp file to use for kdu_expand output

--- a/src/Image/SubFieldImage.php
+++ b/src/Image/SubFieldImage.php
@@ -102,7 +102,9 @@ class Image_SubFieldImage {
 
         $this->desiredToActual = $this->desiredScale / $jp2->getScale();
         $this->scaleFactor     = log($this->desiredToActual, 2);
-        $this->reduce          = max(0, floor($this->scaleFactor));
+		// Make sure result >= 0 with max.
+		// Make sure result <= maxReduction with min.
+        $this->reduce          = min(max(0, floor($this->scaleFactor)), $jp2->getMaxReduction());
 
         $this->subfieldWidth   = $this->imageSubRegion['right'] - $this->imageSubRegion['left'];
         $this->subfieldHeight  = $this->imageSubRegion['bottom'] - $this->imageSubRegion['top'];

--- a/tests/unit_tests/jpeg2000/JP2ImageTest.php
+++ b/tests/unit_tests/jpeg2000/JP2ImageTest.php
@@ -1,0 +1,31 @@
+<?php declare(strict_types=1);
+/**
+ * @author Daniel Garcia-Briseno <daniel.garciabriseno@nasa.gov>
+ */
+
+
+use PHPUnit\Framework\TestCase;
+
+// File under test
+include_once HV_ROOT_DIR.'/../src/Image/JPEG2000/JP2Image.php';
+
+final class JP2ImageTest extends TestCase
+{
+	// Known answer test to confirm this function
+	// detects the known resolution levels in certain files.
+    public function test_getMaxReduction(): void
+    {
+		// file => Clevels
+		$answers = array(
+		    '/var/www/jp2/HRI_EUV/2022/04/01/174/solo_L3_eui-hrieuv174-image_20220401T103005920_V01.jp2' => 5,
+			'/var/www/jp2/AIA/2022/01/01/193/2022_01_01__00_00_52_843__SDO_AIA_AIA_193.jp2' => 8
+			);
+
+		foreach ($answers as $file => $reduction) {
+			// width, height, and scale are not used in this test.
+			$jp2 = new Image_JPEG2000_JP2Image($file, 1024, 1024, 1);
+			$result = $jp2->getMaxReduction();
+			$this->assertEquals($result, $reduction);
+		}
+    }
+}


### PR DESCRIPTION
Using `kdu_expand -record` to get metadata from the file to determine the maximum possible `-reduce` value that will succeed.