### PR TITLE
Override image scale for unexpectedly low values

### DIFF
--- a/src/Database/ImgIndex.php
+++ b/src/Database/ImgIndex.php
@@ -875,8 +875,13 @@ class Database_ImgIndex {
             // In order to handle these images, this
             // workaround attempts to detect those invalid image scales and
             // override them back to 0.6
-            if ($imageScale < 0.05) {
-                $imageScale = 0.6;
+            // The highest invalid image scale is this image below with a scale of 0.15404
+            // Anything below this value will have a scale set back to 0.6
+            // | 111318295 | 2010-12-06 13:14:41 |               0.15404 | HMI Int      |
+            $IMAGE_SCALE_OVERRIDE_THRESHOLD = 0.1541;
+            $IMAGE_SCALE_OVERRIDE_VALUE = 0.6;
+            if ($imageScale < $IMAGE_SCALE_OVERRIDE_THRESHOLD) {
+                $imageScale = $IMAGE_SCALE_OVERRIDE_VALUE;
             }
 
             $meta = array(

--- a/src/Database/ImgIndex.php
+++ b/src/Database/ImgIndex.php
@@ -864,26 +864,6 @@ class Database_ImgIndex {
             // Normalize image scale
             $imageScale = $imageScale * ($dsun / HV_CONSTANT_AU);
 
-            // WORKAROUND FOR INVALID DSUN:
-            // Image scale is expected to be roughly 0.6, though it can be
-            // lower. However there are some images which have an invalid DSun
-            // value which results in an incorrect imageScale value which is
-            // very close to 0, even though the correct scale should still be
-            // somewhere around 0.6. The result is that helioviewer believes the
-            // image to be an extremely high resolution and attempts to scale the image
-            // down to a point that image magick can't process it.
-            // In order to handle these images, this
-            // workaround attempts to detect those invalid image scales and
-            // override them back to 0.6
-            // The highest invalid image scale is this image below with a scale of 0.15404
-            // Anything below this value will have a scale set back to 0.6
-            // | 111318295 | 2010-12-06 13:14:41 |               0.15404 | HMI Int      |
-            $IMAGE_SCALE_OVERRIDE_THRESHOLD = 0.1541;
-            $IMAGE_SCALE_OVERRIDE_VALUE = 0.6;
-            if ($imageScale < $IMAGE_SCALE_OVERRIDE_THRESHOLD) {
-                $imageScale = $IMAGE_SCALE_OVERRIDE_VALUE;
-            }
-
             $meta = array(
                 "scale"      => $imageScale,
                 "width"      => (int) $dimensions[0],
@@ -1500,3 +1480,4 @@ class Database_ImgIndex {
     }
 }
 ?>
+

--- a/src/Database/ImgIndex.php
+++ b/src/Database/ImgIndex.php
@@ -1480,4 +1480,3 @@ class Database_ImgIndex {
     }
 }
 ?>
-

--- a/src/Database/ImgIndex.php
+++ b/src/Database/ImgIndex.php
@@ -864,6 +864,21 @@ class Database_ImgIndex {
             // Normalize image scale
             $imageScale = $imageScale * ($dsun / HV_CONSTANT_AU);
 
+            // WORKAROUND FOR INVALID DSUN:
+            // Image scale is expected to be roughly 0.6, though it can be
+            // lower. However there are some images which have an invalid DSun
+            // value which results in an incorrect imageScale value which is
+            // very close to 0, even though the correct scale should still be
+            // somewhere around 0.6. The result is that helioviewer believes the
+            // image to be an extremely high resolution and attempts to scale the image
+            // down to a point that image magick can't process it.
+            // In order to handle these images, this
+            // workaround attempts to detect those invalid image scales and
+            // override them back to 0.6
+            if ($imageScale < 0.05) {
+                $imageScale = 0.6;
+            }
+
             $meta = array(
                 "scale"      => $imageScale,
                 "width"      => (int) $dimensions[0],

--- a/src/Image/JPEG2000/JP2ImageXMLBox.php
+++ b/src/Image/JPEG2000/JP2ImageXMLBox.php
@@ -116,11 +116,13 @@ class Image_JPEG2000_JP2ImageXMLBox {
     private function _workaroundInvalidDsun($dsun) {
         $DSUN_OVERRIDE_THRESHOLD = HV_CONSTANT_AU * 0.04;
         if ($dsun <= $DSUN_OVERRIDE_THRESHOLD) {
-            // Add an informational log to see
+            // Add an informational log to let us know when this happens. It is expected
+            // in some older files, but not new ones.
             $inst = $this->_getElementValue('INSTRUME');
-            error_log("Patching dsun value to 1AU. Instrument: $inst, Old dsun: $dsun");
+            $date = $this->_getElementValue('DATE');
+            error_log("Patching dsun value to 1AU. Instrument: $inst, date: $date, Old dsun: $dsun");
             // Using 1AU as the default dsun since this
-            // this was already being used as a value for other
+            // was already being used as a value for other
             // cases where dsun is invalid.
             return HV_CONSTANT_AU;
         }

--- a/tests/unit_tests/jpeg2000/JP2ImageTest.php
+++ b/tests/unit_tests/jpeg2000/JP2ImageTest.php
@@ -17,8 +17,8 @@ final class JP2ImageTest extends TestCase
     {
 		// file => Clevels
 		$answers = array(
-		    '/var/www/jp2/HRI_EUV/2022/04/01/174/solo_L3_eui-hrieuv174-image_20220401T103005920_V01.jp2' => 5,
-			'/var/www/jp2/AIA/2022/01/01/193/2022_01_01__00_00_52_843__SDO_AIA_AIA_193.jp2' => 8
+		    HV_JP2_DIR . '/HRI_EUV/2022/04/01/174/solo_L3_eui-hrieuv174-image_20220401T103005920_V01.jp2' => 5,
+			HV_JP2_DIR . '/AIA/2022/01/01/193/2022_01_01__00_00_52_843__SDO_AIA_AIA_193.jp2' => 8
 			);
 
 		foreach ($answers as $file => $reduction) {

--- a/tests/unit_tests/jpeg2000/JP2ImageXMLBoxTest.php
+++ b/tests/unit_tests/jpeg2000/JP2ImageXMLBoxTest.php
@@ -1,0 +1,44 @@
+<?php declare(strict_types=1);
+/**
+ * @author Daniel Garcia-Briseno <daniel.garciabriseno@nasa.gov>
+ */
+
+
+use PHPUnit\Framework\TestCase;
+
+// File under test
+include_once HV_ROOT_DIR.'/../src/Image/JPEG2000/JP2ImageXMLBox.php';
+
+final class JP2ImageXMLBoxTest extends TestCase
+{
+    // Tests the case where DSUN is below 0.04AU which is expected
+    // to be unrealistic and invalid. There are some older jp2 files with
+    // invalid metadata that need to be corrected, this is a temporary
+    // workaround for dealing with those files.
+    public function test_getDsunWorkaroundBadFile(): void
+    {
+        $known_bad_file = HV_JP2_DIR . "/HMI/2010/12/06/continuum/2010_12_06__18_56_41_105__SDO_HMI_HMI_continuum.jp2";
+        // If the file doesn't exist, don't continue with the test.
+        if (!file_exists($known_bad_file)) {
+            $this->markTestSkipped("File to test not present on this system");
+            return;
+        }
+
+        $xmlBox = new Image_JPEG2000_JP2ImageXMLBox($known_bad_file);
+        $this->assertEquals($xmlBox->getDSun(), HV_CONSTANT_AU);
+    }
+
+    public function test_getDsunWorkaroundGoodFile(): void
+    {
+        $known_good_file = HV_JP2_DIR . "/HMI/2022/08/02/magnetogram/2022_08_02__10_47_53_000__SDO_HMI_HMI_magnetogram.jp2";
+        // If the file doesn't exist, don't continue with the test.
+        if (!file_exists($known_good_file)) {
+            $this->markTestSkipped("File to test not present on this system");
+            return;
+        }
+
+        $xmlBox = new Image_JPEG2000_JP2ImageXMLBox($known_good_file);
+        $this->assertNotEquals($xmlBox->getDSun(), HV_CONSTANT_AU);
+    }
+
+}


### PR DESCRIPTION
Works around the problem in #194 