### PR TITLE
Don't add null frames during jpx preprocessing

### DIFF
--- a/src/Image/JPEG2000/HelioviewerJPXImage.php
+++ b/src/Image/JPEG2000/HelioviewerJPXImage.php
@@ -210,9 +210,6 @@ class Image_JPEG2000_HelioviewerJPXImage extends Image_JPEG2000_JPXImage {
 				$filepath = HV_JP2_DIR.$results['filepath'].'/'.$results['filename'];
 				array_push($images, $filepath);
 				array_push($dates, strtotime($results['date']));
-			}else{
-				array_push($images, null);
-				array_push($dates, null);
 			}
 		}
 


### PR DESCRIPTION
Fixes issues with getJPXClosestToMidPoint that was caught by hvpy's CI.
https://github.com/Helioviewer-Project/python-api/actions/runs/3692544067/attempts/2