### PR TITLE
Remove flare predictions from data coverage result.

### DIFF
--- a/src/Database/Statistics.php
+++ b/src/Database/Statistics.php
@@ -2292,8 +2292,7 @@ class Database_Statistics {
         $data = [];
         switch ($eventDetails['event_type']) {
             case "FP":
-                include_once HV_ROOT_DIR."/../src/Database/FlarePredictionDatabase.php";
-                $data = Database_FlarePredictionDatabase::GetPredictionCoverage($eventDetails, $resolution, $startDate, $endDate, $currentDate);
+                // Don't include flare prediction data in the coverage since the volume of predictions muddles the data.
                 break;
         }
         if (in_array($resolution, ["m", "5m", "15m"])) {

--- a/src/Database/Statistics.php
+++ b/src/Database/Statistics.php
@@ -2293,6 +2293,7 @@ class Database_Statistics {
         switch ($eventDetails['event_type']) {
             case "FP":
                 // Don't include flare prediction data in the coverage since the volume of predictions muddles the data.
+                // See https://github.com/Helioviewer-Project/api/pull/287 for more info
                 break;
         }
         if (in_array($resolution, ["m", "5m", "15m"])) {


### PR DESCRIPTION
This ultimately removes the flare prediction coverage from the image timeline. We chose to leave this out since the volume of data muddles the result. The timeline isn't the right place for this data for predictions.

> The events timeline is useful because the solar features and events are quasi-random, so you want to know when they happen

But for flare predictions which come in regularly, this is what you get.
<img width="699" alt="image" src="https://user-images.githubusercontent.com/94071409/230932434-a5694d9f-d190-48ac-89cb-21f87e6c8765.png">
