### PR TITLE
Remove plural noun for flare event types

### DIFF
--- a/src/Database/FlarePredictionDatabase.php
+++ b/src/Database/FlarePredictionDatabase.php
@@ -237,7 +237,7 @@ class Database_FlarePredictionDatabase
         }
 
         $hef_predictions = [
-            'name' => 'Solar Flare Predictions',
+            'name' => 'Solar Flare Prediction',
             'pin' => 'FP',
             'groups' => []
         ];


### PR DESCRIPTION
Fixes the typo of showing "Solar Flare Prediction**ss**"