### PR TITLE
New prediction schema

### DIFF
--- a/install/database/2023_04_11_update_flare_table.sql
+++ b/install/database/2023_04_11_update_flare_table.sql
@@ -1,0 +1,43 @@
+-- Nuke the existing flare predictions tables.
+DROP TABLE IF EXISTS flare_predictions;
+DROP TABLE IF EXISTS flare_datasets;
+CREATE TABLE flare_datasets (
+    id INT UNSIGNED NOT NULL AUTO_INCREMENT,
+    name VARCHAR(255) NOT NULL,
+    PRIMARY KEY (id),
+    UNIQUE KEY (name)
+);
+
+-- Only create columns for information that is required to query
+-- We want to keep all metadata provided by the CCMC APIs, so we can't rely on a schema.
+-- In theory, we could make the only columns be the id and json, but as the table grows, there may be a performance problems with querying json columns.
+CREATE TABLE flare_predictions (
+    id INT UNSIGNED NOT NULL AUTO_INCREMENT,
+    dataset_id INT UNSIGNED NOT NULL,
+    start_window DATETIME NOT NULL,
+    end_window DATETIME NOT NULL,
+    issue_time DATETIME NOT NULL,
+    hpc_x FLOAT,
+    hpc_y FLOAT,
+    json_data JSON NOT NULL,
+    sha256 VARCHAR(64) NOT NULL,
+    PRIMARY KEY (id),
+    FOREIGN KEY (dataset_id) REFERENCES flare_datasets(id),
+    UNIQUE KEY (sha256),
+    INDEX `issue_time_idx` (`issue_time`)
+);
+
+INSERT INTO flare_datasets (id, name) VALUES
+    ( 1, "SIDC_Operator_REGIONS"),
+    ( 2, "BoM_flare1_REGIONS"),
+    ( 3, "ASSA_1_REGIONS"),
+    ( 4, "ASSA_24H_1_REGIONS"),
+    ( 5, "AMOS_v1_REGIONS"),
+    ( 6, "ASAP_1_REGIONS"),
+    ( 7, "MAG4_LOS_FEr_REGIONS"),
+    ( 8, "MAG4_LOS_r_REGIONS"),
+    ( 9, "MAG4_SHARP_FE_REGIONS"),
+    (10, "MAG4_SHARP_REGIONS"),
+    (11, "MAG4_SHARP_HMI_REGIONS"),
+    (12, "AEffort_REGIONS")
+;

--- a/management/events/ccmc/import_predictions.py
+++ b/management/events/ccmc/import_predictions.py
@@ -37,7 +37,7 @@ def insert_predictions_into_db(predictions: list):
     db = get_db()
     cursor = db.cursor()
     data = as_list(predictions)
-    result = cursor.executemany("REPLACE INTO `flare_predictions` (`dataset_id`, `start_window`, `end_window`, `issue_time`, `c`, `m`, `x`, `cplus`, `mplus`, `latitude`, `longitude`, `hpc_x`, `hpc_y`, `sha256`) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)",
+    result = cursor.executemany("REPLACE INTO `flare_predictions` (`dataset_id`, `start_window`, `end_window`, `issue_time`, `hpc_x`, `hpc_y`, `json_data`, `sha256`) VALUES (%s, %s, %s, %s, %s, %s, %s, %s)",
                           data)
     cursor.close()
     db.commit()
@@ -59,15 +59,9 @@ def as_list(predictions):
                            prediction.start_window,
                            prediction.end_window,
                            prediction.issue_time,
-                           getattr_or_none(prediction, 'C'),
-                           getattr_or_none(prediction, 'M'),
-                           getattr_or_none(prediction, 'X'),
-                           getattr_or_none(prediction, 'CPlus'),
-                           getattr_or_none(prediction, 'MPlus'),
-                           prediction.latitude,
-                           prediction.longitude,
                            prediction.hpc_x,
                            prediction.hpc_y,
+                           prediction.json,
                            prediction.sha256))
         else:
             ignore_count += 1

--- a/management/events/ccmc/prediction.py
+++ b/management/events/ccmc/prediction.py
@@ -1,6 +1,7 @@
 from astropy.coordinates import SkyCoord
 from sunpy.coordinates import frames
 import astropy.units as u
+import json
 
 def hgs2hpc(lat, lon, obstime):
     coord = SkyCoord(lon*u.deg, lat*u.deg, frame=frames.HeliographicStonyhurst, observer="earth", obstime=obstime)
@@ -42,6 +43,8 @@ class Prediction:
             return self.hpc.Ty.value
         if name == "sha256":
             return self.gen_sha256()
+        if name == "json":
+            return self._jsonify()
 
         for i in range(len(self.parameters)):
             # Attribute only exists if it is not a fill value. Fill is used for values which have no data.
@@ -78,6 +81,18 @@ class Prediction:
         Returns a string representing the given label and value
         """
         return f"{label}: {value}".rjust(10)
+
+    def _jsonify(self):
+        """
+        Converts the flare prediction hapi data into a json string with parameters as keys
+        """
+        jsonObject = {}
+        for i in range(len(self.parameters)):
+            # Attribute only exists if it is not a fill value. Fill is used for values which have no data.
+            key = self.parameters[i]['name']
+            value = self.data[i]
+            jsonObject[key] = value
+        return json.dumps(jsonObject)
 
     def __str__(self):
         return f"{self.dataset} Prediction issued at {self.issue_time} for " + f"({self.latitude},{self.longitude}) (lat,lon).".rjust(22) + self._label_str("c", self.C) + self._label_str("c+", self.CPlus) + self._label_str("m", self.M) + self._label_str("m+", self.MPlus) + self._label_str("x", self.X)


### PR DESCRIPTION
Instead of trying to normalize a schema which is different for several datasets, this change updates the flare prediction database to store the raw API result.
This allows us to still do our own internal processing on the data, but also present the data in its pure form to the user.