### PR TITLE
Enable helioviewer to run in docker compose environment

### DIFF
--- a/install/helioviewer/HelioviewerConsoleInstaller.py
+++ b/install/helioviewer/HelioviewerConsoleInstaller.py
@@ -13,79 +13,75 @@ class HelioviewerConsoleInstaller:
     """Text-based installer class"""
     def __init__(self, options):
         self.options = options
-        
+
     def getFilePath(self):
         '''Prompts the user for the directory information'''
-    
+
         path = get_input("Location of JP2 Images: ")
         while not os.path.isdir(path):
             print("That is not a valid directory! Please try again.")
             path = get_input("Location of JP2 Images: ")
-    
+
         return path
-    
+
     def getDatabaseType(self):
         ''' Prompts the user for the database type '''
         dbtypes = {1: "mysql", 2: "postgres"}
-        
+
         while True:
             print("Please select the desired database to use for installation:")
             print("   [1] MySQL")
             print("   [2] PostgreSQL")
             choice = get_input("Choice: ")
-            
+
             if choice not in ['1', '2']:
                 print("Sorry, that is not a valid choice.")
             else:
                 return dbtypes[int(choice)]
-            
+
     def getDatabasename(self):
         ''' Prompts the user for the database name '''
 
         dbname = get_input("    Database name [helioviewer]: ")
-   
+
         # Default values
         if not dbname: dbname = "helioviewer"
-    
+
         return dbname
-                
+
     def shouldSetupSchema(self):
         ''' Prompts the user for the database type '''
         options = {1: True, 2: False}
-        
+
         while True:
             print("Would you like to create the database schema used by "
                   "Helioviewer.org?:")
             print("   [1] Yes")
             print("   [2] No")
             choice = get_input("Choice: ")
-            
+
             if choice not in ['1', '2']:
                 print("Sorry, that is not a valid choice.")
             else:
                 return options[int(choice)]
-    
+
     def getDatabaseInfo(self):
         ''' Gets database type and administrator login information '''
         import getpass
-        
-        while True:  
+
+        while True:
             dbtype = self.getDatabaseType()
-            dbuser = get_input("    Username: ")        
+            dbuser = get_input("    Username: ")
             dbpass = getpass.getpass("    Password: ")
-        
+
             # Default values
             if not dbuser:
                 dbuser = "root"
 
             # MySQL?
             mysql = dbtype is "mysql"
-            
-            if not check_db_info(dbuser, dbpass, mysql):
-                print("Unable to connect to the database. Please check your "
-                      "login information and try again.")
-            else:
-                return dbuser,dbpass,mysql        
+
+            return dbuser,dbpass,mysql
 
     def getNewUserInfo(self):
         ''' Prompts the user for the required database information '''
@@ -93,19 +89,19 @@ class HelioviewerConsoleInstaller:
         # Get new user information (Todo 2009/08/24: validate input form)
         dbuser = get_input("    Username [helioviewer]: ")
         dbpass = get_input("    Password [helioviewer]: ")
-    
+
         # Default values
         if not dbuser:
             dbuser = "helioviewer"
         if not dbpass:
             dbpass = "helioviewer"
-    
+
         return dbuser, dbpass
 
     def printGreeting(self):
         ''' Prints a greeting to the user'''
         subprocess.call("clear", shell=True)
-        
+
         print("""\
 ====================================================================
 = Helioviewer Database Population Script                           =
@@ -120,13 +116,13 @@ def loadTextInstaller(options):
     ''' Loads the text-based installation tool '''
     app = HelioviewerConsoleInstaller(options)
     app.printGreeting()
-    
+
     # Filepath
     path = app.getFilePath()
-    
+
     # Locate jp2 images in specified filepath
     images = traverse_directory(path)
-    
+
     # Check to make sure the filepath contains jp2 images
     if len(images) is 0:
         print("No JPEG 2000 images found. Exiting installation.")
@@ -139,21 +135,21 @@ def loadTextInstaller(options):
         print("Please enter new database information:")
         dbname = app.getDatabasename()
         hvuser, hvpass = app.getNewUserInfo()
-        
+
         print("")
-        
+
         # Get database information
         print("Please enter existing database admin information:")
         dbuser, dbpass, mysql = app.getDatabaseInfo()
 
         # Setup database schema
         db, cursor = setup_database_schema(hvuser, hvpass, "localhost", dbname, dbuser, dbpass, mysql)
-    
+
     else:
         # Get database information
         print("Please enter Helioviewer.org database name")
         dbname = app.getDatabasename()
-        
+
         print("Please enter Helioviewer.org database user information")
         dbuser, dbpass, mysql = app.getDatabaseInfo()
         cursor = get_db_cursor("localhost", dbname, dbuser, dbpass, mysql)
@@ -165,25 +161,25 @@ def loadTextInstaller(options):
     cursor.close()
 
     print("Finished!")
-    
+
 def loadUpdater(options):
     ''' Loads the text-based installation tool and runs it in update-mode '''
     app = HelioviewerConsoleInstaller(options)
-    
+
     # MySQL?
     mysql = options.dbtype == "mysql"
-        
+
     db, cursor = get_db_cursor("localhost", options.dbname, options.dbuser, options.dbpass, mysql)
 
     print("Processing Images...")
 
     # Insert image information into database
     process_jp2_images(options.files, options.basedir, db, cursor, mysql)
-    
+
     cursor.close()
 
     print("Finished!")
-    
+
 # raw_input
 if sys.version_info[0] >= 3:
     get_input = input

--- a/install/helioviewer/db.py
+++ b/install/helioviewer/db.py
@@ -113,10 +113,14 @@ def create_db(adminuser, adminpass, dbhost, dbname, dbuser, dbpass, mysql, adapt
 
     TODO (2009/08/18) Catch error when db already exists and gracefully exit
     """
+    if dbhost == "localhost":
+        hostname = dbhost
+    else:
+        hostname = '%'
 
     create_str = "CREATE DATABASE IF NOT EXISTS %s;" % dbname
-    user_str = "CREATE USER '%s'@'localhost' IDENTIFIED BY '%s';" % (dbuser, dbpass)
-    grant_str = "GRANT ALL ON %s.* TO '%s'@'localhost';" % (dbname, dbuser)
+    user_str = "CREATE USER '%s'@'%s' IDENTIFIED BY '%s';" % (dbuser, hostname, dbpass)
+    grant_str = "GRANT ALL ON %s.* TO '%s'@'%s';" % (dbname, dbuser, hostname)
 
     if mysql:
         try:

--- a/install/helioviewer/installer/console.py
+++ b/install/helioviewer/installer/console.py
@@ -103,8 +103,8 @@ class HelioviewerConsoleInstaller:
         except ReferenceError as err:
             print("ReferenceError:", err)
             sys.exit()
-        except:
-            print("Specified database already exists! Exiting installer. Error:", sys.exc_info()[0])
+        except Exception as e:
+            print("Specified database already exists! Exiting installer. Error: ", str(e))
             sys.exit()
 
     def get_filepath(self):
@@ -183,10 +183,7 @@ class HelioviewerConsoleInstaller:
             # MySQL?
             mysql = dbtype is "mysql"
 
-            if not check_db_info(dbuser, dbpass, mysql):
-                print("Unable to connect to the database. Please check your login information and try again.")
-            else:
-                return dbuser,dbpass,mysql
+            return dbuser,dbpass,mysql
 
     def get_new_user_info(self):
         ''' Prompts the user for the required database information '''

--- a/src/Config.php
+++ b/src/Config.php
@@ -58,6 +58,9 @@ class Config {
 
         $keys = substr($file, 0, strripos($file, '/')).'/Private.php';
         include_once $keys;
+
+        include_once HV_ROOT_DIR.'/../lib/Resque.php';
+        Resque::setBackend(HV_REDIS_HOST . ":" . HV_REDIS_PORT);
     }
 
     /**

--- a/src/Image/ImageType/CORImage.php
+++ b/src/Image/ImageType/CORImage.php
@@ -175,7 +175,12 @@ class Image_ImageType_CORImage extends Image_HelioviewerImage {
             $mask->negateImage(true);
 
             $imagickImage->setImageClipMask($mask);
-            $imagickImage->setImageOpacity($this->options['opacity'] / 100);
+            $opacity = $this->imageOptions['opacity'] / 100;
+            try {
+                @$imagickImage->setImageOpacity($opacity);
+            } catch (Throwable $e) {
+                $imagickImage->setImageAlpha($opacity);
+            }
         }
 
         $mask->destroy();

--- a/src/Image/ImageType/COSMOImage.php
+++ b/src/Image/ImageType/COSMOImage.php
@@ -107,7 +107,7 @@ class Image_ImageType_COSMOImage extends Image_HelioviewerImage {
         else {
             $maskScaleFactor = 1;
         }
-		
+
 		$offsetX = $this->offsetX;
 		$offsetY = $this->offsetY;
 
@@ -115,7 +115,7 @@ class Image_ImageType_COSMOImage extends Image_HelioviewerImage {
 			$offsetX = $this->originalOffsetX;
 			$offsetY = $this->originalOffsetY;
 		}
-		
+
         $maskTopLeftX = ($this->imageSubRegion['left'] +
                         ($maskWidth  - $this->jp2->getWidth()) /2
                       - $offsetX) * $maskScaleFactor;
@@ -155,9 +155,14 @@ class Image_ImageType_COSMOImage extends Image_HelioviewerImage {
             $mask->negateImage(true);
 
             $imagickImage->setImageClipMask($mask);
-            $imagickImage->setImageOpacity($this->options['opacity'] / 100);
+            $opacity = $this->imageOptions['opacity'] / 100;
+            try {
+                @$imagickImage->setImageOpacity($opacity);
+            } catch (Throwable $e) {
+                $imagickImage->setImageAlpha($opacity);
+            }
         }
-		
+
         $mask->destroy();
     }
 }

--- a/src/Image/ImageType/LASCOImage.php
+++ b/src/Image/ImageType/LASCOImage.php
@@ -116,7 +116,7 @@ class Image_ImageType_LASCOImage extends Image_HelioviewerImage {
         else {
             $maskScaleFactor = 1;
         }
-		
+
 		$offsetX = $this->offsetX;
 		$offsetY = $this->offsetY;
 
@@ -124,7 +124,7 @@ class Image_ImageType_LASCOImage extends Image_HelioviewerImage {
 			$offsetX = $this->originalOffsetX;
 			$offsetY = $this->originalOffsetY;
 		}
-		
+
         $maskTopLeftX = ($this->imageSubRegion['left'] +
                         ($maskWidth  - $this->jp2->getWidth()) /2
                       - $offsetX) * $maskScaleFactor;
@@ -164,9 +164,14 @@ class Image_ImageType_LASCOImage extends Image_HelioviewerImage {
             $mask->negateImage(true);
 
             $imagickImage->setImageClipMask($mask);
-            $imagickImage->setImageOpacity($this->options['opacity'] / 100);
+            $opacity = $this->imageOptions['opacity'] / 100;
+            try {
+                @$imagickImage->setImageOpacity($opacity);
+            } catch (Throwable $e) {
+                $imagickImage->setImageAlpha($opacity);
+            }
         }
-		
+
         $mask->destroy();
     }
 }

--- a/src/Image/SubFieldImage.php
+++ b/src/Image/SubFieldImage.php
@@ -490,7 +490,12 @@ class Image_SubFieldImage {
         // Using @ to mask setImageOpacity deprecation notice.
         // This can be removed if we upgrade to ImageMagick 7 and use
         // setImageAlpha instead of setImageOpacity.
-        @$imagickImage->setImageOpacity($this->imageOptions['opacity'] / 100);
+        $opacity = $this->imageOptions['opacity'] / 100;
+        try {
+            @$imagickImage->setImageOpacity($opacity);
+        } catch (Throwable $e) {
+            $imagickImage->setImageAlpha($opacity);
+        }
     }
 
     /**

--- a/src/Job/MovieBuilder.php
+++ b/src/Job/MovieBuilder.php
@@ -73,7 +73,7 @@ class Job_MovieBuilder
             return;
         }
         # Get current time estimation counter
-        $redis = new Redisent('localhost');
+        $redis = new Redisent(HV_REDIS_HOST, HV_REDIS_PORT);
         $totalWait = (int) $redis->get('helioviewer:movie_queue_wait');
         $redis->decrby('helioviewer:movie_queue_wait', min($totalWait, $this->args['eta']));
     }

--- a/src/Module/Movies.php
+++ b/src/Module/Movies.php
@@ -60,7 +60,7 @@ class Module_Movies implements Module {
         include_once HV_ROOT_DIR.'/../src/Database/ImgIndex.php';
 
         // Connect to redis
-        $redis = new Redisent('localhost');
+        $redis = new Redisent(HV_REDIS_HOST, HV_REDIS_PORT);
 
         // If the queue is currently full, don't process the request
         $queueSize = Resque::size(HV_MOVIE_QUEUE);
@@ -237,7 +237,7 @@ class Module_Movies implements Module {
         include_once HV_ROOT_DIR.'/../src/Movie/HelioviewerMovie.php';
 
         // Connect to redis
-        $redis = new Redisent('localhost');
+        $redis = new Redisent(HV_REDIS_HOST, HV_REDIS_PORT);
 
         // If the queue is currently full, don't process the request
         $queueSize = Resque::size(HV_MOVIE_QUEUE);

--- a/src/Movie/HelioviewerMovie.php
+++ b/src/Movie/HelioviewerMovie.php
@@ -98,6 +98,7 @@ class Movie_HelioviewerMovie {
         $this->_cachedir = Movie_HelioviewerMovie::CACHE_DIR;
         $this->_filename = urlencode($publicId.'.cache');
 
+        $this->_cached = false;
         if ( HV_DISABLE_CACHE !== true ) {
             $cache = new Helper_Serialize($this->_cachedir, $this->_filename, 60);
             $info = $cache->readCache($verifyAge=true);
@@ -105,7 +106,7 @@ class Movie_HelioviewerMovie {
             // users get the fastest notification of the movie being done.
             // This also fixes an issue where the progress data breaks because the cached status
             // is processing, but the movie is done.
-            if ( $info !== false && $info['status'] != self::STATUS_PROCESSING ) {
+            if ( $info !== false && $info['status'] >= self::STATUS_COMPLETED ) {
                 $this->_cached = true;
             }
         }
@@ -738,6 +739,7 @@ class Movie_HelioviewerMovie {
     private function _setMovieProperties() {
         $this->_dbSetup();
 
+        $this->_prepDates();
 
         $this->filename = $this->_buildFilename();
 


### PR DESCRIPTION
These changes fix some issues that were preventing HV from running in compose.
Mainly:
- Some redis connections were hard coded to `localhost` even though we have an `HV_REDIS_HOST` configuration variable
- Database setup script interface claimed to allow specifying the database server, but always created the user at 'localhost' which prevented later connections.
- Patch to image magick to use setImageAlpha if it's available instead of the deprecated setImageOpacity.