### PR TITLE
Fix problem with checkYoutubeAuth

### DIFF
--- a/src/Movie/YouTube.php
+++ b/src/Movie/YouTube.php
@@ -41,19 +41,6 @@ class Movie_YouTube {
         // Post-auth upload URL
         $redirect = filter_var(HV_WEB_ROOT_URL . '?action=uploadMovieToYouTube&html=true', FILTER_SANITIZE_URL);
 		$this->_httpClient->setRedirectUri($redirect);
-
-		//set proxy config for curl io
-		if(!empty(HV_PROXY_HOST)){
-			$io = new Google_IO_Curl($this->_httpClient);
-			$curloptions = array();
-			$curloptions[CURLOPT_PROXY] = HV_PROXY_HOST;
-			if(!empty(HV_PROXY_USER_PASSWORD)){
-				$curloptions[CURLOPT_PROXYUSERPWD] = HV_PROXY_USER_PASSWORD;
-			}
-			$io->setOptions($curloptions);
-			$this->_httpClient->setIo($io);
-		}
-
     }
 
     /**

--- a/tests/unit_tests/movies/YoutubeUploadTest.php
+++ b/tests/unit_tests/movies/YoutubeUploadTest.php
@@ -1,0 +1,26 @@
+<?php declare(strict_types=1);
+/**
+ * @author Daniel Garcia-Briseno <daniel.garciabriseno@nasa.gov>
+ */
+
+use PHPUnit\Framework\TestCase;
+
+final class YoutubeUploadTest extends TestCase
+{
+    /**
+     * Covers https://github.com/Helioviewer-Project/helioviewer.org/issues/592
+     * Youtube Upload failed from check youtube auth due to incorrect use of
+     * Google API.
+     * @runInSeparateProcess
+     */
+    public function testCheckYoutubeAuth() {
+        $params = array("action" => "checkYoutubeAuth");
+        $movies = new Module_Movies($params);
+        ob_start();
+        $movies->execute();
+        $output = ob_get_contents();
+        ob_end_clean();
+        $this->assertEquals("false", $output);
+    }
+}
+


### PR DESCRIPTION
Fixes https://github.com/Helioviewer-Project/helioviewer.org/issues/592

Issue was caused by changing Google PHP API from a git submodule to a composer dependency.
It wasn't caught in local testing because the code was different for having a proxy vs. not having a proxy and local testing did not have a proxy.

This change removes the branching, so code the code is always the same.

This removes the usage of `Google_IO_Curl` which was removed in the Google PHP API.
Previously we used this to set the proxy server to use for the request. This is now controlled via the `HTTP(S)_PROXY` environment variable.