### PR TITLE
Add enable3d to schema as optional field

### DIFF
--- a/docroot/schema/client_state.schema.json
+++ b/docroot/schema/client_state.schema.json
@@ -21,7 +21,8 @@
         },
         "celestialBodies": {
             "$ref": "https://api.helioviewer.org/schema/celestial_bodies.schema.json"
-        }
+        },
+        "enable3d": { "type": "boolean" }
     },
     "required": [
         "date",


### PR DESCRIPTION
- Allows shareViewport to include whether helioviewer is in 3d or 2d mode.