### PR TITLE
fix misuse of = in db query, was keeping build times null

### DIFF
--- a/src/Database/ImgIndex.php
+++ b/src/Database/ImgIndex.php
@@ -210,8 +210,8 @@ class Database_ImgIndex {
         $sql = sprintf(
                    "UPDATE movies "
                  . "SET "
-                 .     "buildTimeStart " . " ='%s', "
-                 .     "buildTimeEnd= "  . " ='%s' "
+                 .     "buildTimeStart='%s', "
+                 .     "buildTimeEnd='%s' "
                  . "WHERE id "           . " = %d "
                  . "LIMIT 1;",
                  $this->_dbConnection->link->real_escape_string(


### PR DESCRIPTION
Fix buildTimeEnd not being saved to movies table

A typo in the UPDATE query caused a SQL syntax error, preventing movie build times from being recorded. Fixed the query so both buildTimeStart and buildTimeEnd are saved correctly.