### PR TITLE
Update image timeline separate from events timeline

### DIFF
--- a/management/data/update_data_timeline.php
+++ b/management/data/update_data_timeline.php
@@ -1,0 +1,73 @@
+<?php
+require_once '../config.php';
+
+/**
+ * prints script usage information.
+ * Optionally exits the program as well
+ * @param $name String Name of the script to print on the cmd line
+ */
+function print_usage($name) {
+	echo "Usage:
+   $name <start date> <end date>
+
+Updates the image timeline for the given time range.
+\n";
+}
+
+function parse_args($argv) {
+	// Use getopt to parse command line options
+	$opts = getopt('h', ['help'], $rest_index);
+	if ($opts) {
+		foreach ($opts as $opt => $value) {
+			switch ($opt) {
+				// Check if '-h' or '--help' was given
+				case "h":
+				case "help":
+					print_usage($argv[0]);
+					exit(0);
+			}
+		}
+	}
+
+	// Get the positional parameters from the command line args
+	$args = array_slice($argv, $rest_index);
+	// Make sure there are 2 arguments
+	$count = count($args);
+
+	if ($count != 2) {
+		echo "Error: Unexpected number of arguments given\n\n";
+		print_usage($argv[0], true);
+		exit(1);
+	}
+
+	// Parse dates into unix time and make sure times conform to UTC time.
+	$tz = new DateTimeZone("UTC");
+	$start = new DateTimeImmutable($args[0], $tz);
+	$end = new DateTimeImmutable($args[1], $tz);
+	$format = 'Y-m-d H:i:s';
+
+	$result = [
+		'start' => $start->format($format),
+		'end' => $end->format($format)
+	];
+	return $result;
+}
+
+function updateTimeline($start, $end) {
+	require_once HV_ROOT_DIR.'/../src/Database/Statistics.php';
+	echo "Updating data coverage timeline\n";
+	$stats = new Database_Statistics();
+	$success = $stats->updateImageCoverageOverRange($start, $end);
+	if ($success) {
+		echo "Successfully updated image timeline\n";
+	} else {
+		echo "Failed to update timeline.\n";
+		echo "See logs for details.\n";
+	}
+}
+
+$args = parse_args($argv);
+$start = $args['start'];
+$end = $args['end'];
+updateTimeline($start, $end);
+

--- a/src/Database/Statistics.php
+++ b/src/Database/Statistics.php
@@ -1751,11 +1751,11 @@ class Database_Statistics {
     }
 
     /**
-     * Update data source coverage for the given time period
+     * Update the data precomputed statistics for the Image Timeline over the given time range.
      * @param datestring $start Start time for the range to update
      * @param datestring $end   End time for the range to update
      */
-    public function updateDataCoverageOverRange($start, $end) {
+    public function updateImageCoverageOverRange($start, $end) {
         $startFormat = 'Y-m-d 00:00:00';
         $endFormat = 'Y-m-d 23:59:59';
         $defaultTimeFormat = 'Y-m-d H:i:s';
@@ -1786,7 +1786,16 @@ class Database_Statistics {
                 'GROUP BY ' .
                     'bin, ' .
                     'sourceId;';
-        $result = $this->_dbConnection->query($sql);
+        return $this->_dbConnection->query($sql);
+    }
+
+    /**
+     * Update data source coverage for the given time period
+     * @param datestring $start Start time for the range to update
+     * @param datestring $end   End time for the range to update
+     */
+    public function updateDataCoverageOverRange($start, $end) {
+        $result = $this->updateImageCoverageOverRange($start, $end);
 
         // 30m Update Events Data coverage. Align input to 30m mark
         $startDate = clone $alignedStartDate;


### PR DESCRIPTION
- Add script to update the Image Timeline

Recently we had to update the timeline after backfilling KCor data, and it was taking unreasonably long to update the image timeline, this resolves that problem.

This should be used to update the image timeline whenever we backfill data.
Previously this updating the image timeline and events timeline were tied together, but updating events timeline takes much longer.
