### PR TITLE
Helpful downloader patches

### DIFF
--- a/install/helioviewer/hvpull/browser/basebrowser.py
+++ b/install/helioviewer/hvpull/browser/basebrowser.py
@@ -8,7 +8,7 @@ class BaseDataBrowser:
         """Gets a list of directories to be queried for the given time range"""
         return None
     
-    def get_files(self, uri, extension):
+    def get_files(self, uri, extension, filter_func: callable | None = None):
         """Get all the files that end with specified extension at the uri"""
         return None
     

--- a/install/helioviewer/hvpull/browser/httpbrowser.py
+++ b/install/helioviewer/hvpull/browser/httpbrowser.py
@@ -112,7 +112,7 @@ class HTTPDataBrowser(BaseDataBrowser):
 
     def _query(self, location):
         """Get a list of files and folders at the specified remote location"""
-        # query the remote location for the list of files and subdirectories
+        # query the remote location for the list of files and subdirectories.
 
         if (sys.version_info >= (3, 0)):
             url_lister = URLLister()

--- a/install/helioviewer/hvpull/browser/httpbrowser.py
+++ b/install/helioviewer/hvpull/browser/httpbrowser.py
@@ -22,9 +22,9 @@ if (sys.version_info >= (3, 0)):
             usock = urllib.request.urlopen(uri)
             self.feed(usock.read().decode(usock.headers.get_content_charset()))
             usock.close()
-        
+
             return self.urls
-        
+
         def reset(self):
             """Reset state of URLLister"""
             HTMLParser.reset(self)
@@ -58,7 +58,7 @@ else:
                 print (e)
 
             return self.urls
-        
+
         def reset(self):
             """Reset state of URLLister"""
             SGMLParser.reset(self)
@@ -73,7 +73,7 @@ class HTTPDataBrowser(BaseDataBrowser):
     def __init__(self, server):
         BaseDataBrowser.__init__(self, server)
         socket.setdefaulttimeout(60)
-        
+
     def get_directories(self, start_date, end_date):
         """Generates a list of remote directories which may be queried
         for files corresponding to the requested range. Note that these
@@ -81,17 +81,21 @@ class HTTPDataBrowser(BaseDataBrowser):
         # filter(lambda url: url.endswith("/"), self._query(location))
         return self.server.compute_directories(start_date, end_date)
 
-    def get_files(self, location, extension):
+    def get_files(self, location, extension, filter_func: callable | None = None):
         """Get all the files that end with specified extension at the uri"""
         files = None
         num_retries = 0
-        
+
         # Get a list of the files at the remote location, if it exists
         # To avoid spending too much time, we will timeout after a short time
         # and retry up to 10 times.
         while files is None and num_retries <= 10:
             try:
+                # Only grab files with the matching file extension
                 files = filter(lambda url: url.endswith("." + extension), self._query(location))
+                # If there is a user-defined filter function, use that to only get those specific files.
+                if filter_func is not None:
+                    files = filter(filter_func, files)
             except IOError as e:
                 if isinstance(e.strerror, socket.error):
                     # if server is unreachable, raise an exception
@@ -105,10 +109,10 @@ class HTTPDataBrowser(BaseDataBrowser):
                     files = []
 
         return files
-    
+
     def _query(self, location):
         """Get a list of files and folders at the specified remote location"""
-        # query the remote location for the list of files and subdirectories 
+        # query the remote location for the list of files and subdirectories
 
         if (sys.version_info >= (3, 0)):
             url_lister = URLLister()
@@ -121,4 +125,4 @@ class HTTPDataBrowser(BaseDataBrowser):
         urls = filter(lambda url: url[0] != "/" and url[0] != "?", result)
 
         return [os.path.join(location, url) for url in urls]
-    
+

--- a/install/helioviewer/hvpull/browser/localbrowser.py
+++ b/install/helioviewer/hvpull/browser/localbrowser.py
@@ -14,7 +14,7 @@ class LocalDataBrowser(BaseDataBrowser):
         """Get a list of directories at the passed uri"""
         return self.server.compute_directories(start_date, end_date)
 
-    def get_files(self, location, extension):
+    def get_files(self, location, extension, filter_func: callable | None = None):
         """Get all the files that end with specified extension at the uri"""
 
         # ensure the location exists
@@ -25,5 +25,8 @@ class LocalDataBrowser(BaseDataBrowser):
                 lambda f: f.endswith("." + extension), os.listdir(full_path)
             )
             files = [os.path.join(full_path, f) for f in filenames]
+
+        if filter_func is not None:
+            files = list(filter(filter_func, files))
 
         return files

--- a/install/helioviewer/hvpull/net/daemon.py
+++ b/install/helioviewer/hvpull/net/daemon.py
@@ -201,6 +201,8 @@ class ImageRetrievalDaemon:
         if any new files have appeared since the first execution. This continues
         until no new files are found (for xxx minutes?)
         """
+        if (starttime > endtime):
+            raise ValueError(f"Start Time {starttime} is ahead of End Time {endtime}. No files would be downloaded.")
         urls = []
 
         fmt = '%Y-%m-%d %H:%M:%S'

--- a/install/helioviewer/hvpull/net/daemon.py
+++ b/install/helioviewer/hvpull/net/daemon.py
@@ -174,7 +174,7 @@ class ImageRetrievalDaemon:
             # get a list of files available
             # self.oldest_timestamp gets set by query() during the first run
             # before the main loop.
-            self.query(starttime, now)
+            self.query(self.oldest_timestamp, now)
 
             self.sleep()
 
@@ -241,6 +241,7 @@ class ImageRetrievalDaemon:
                 try:
                     # Filter by time range
                     filtered = self._filter_files_by_time(url_list, starttime, endtime)
+                    # Filter to only download new files that have not already been downloaded previously.
                     filtered = list(filter(self._filter_new, filtered))
                 except mysqld.OperationalError:
                     # MySQL has gone away -- try again in 5s

--- a/install/helioviewer/hvpull/net/daemon.py
+++ b/install/helioviewer/hvpull/net/daemon.py
@@ -421,7 +421,7 @@ class ImageRetrievalDaemon:
                     return []
 
                 try:
-                    matches = browser.get_files(directory, "jp2")
+                    matches = browser.get_files(directory, "jp2", browser.server.filter)
 
                     files.extend(matches)
                 except NetworkError:

--- a/install/helioviewer/hvpull/net/daemon.py
+++ b/install/helioviewer/hvpull/net/daemon.py
@@ -325,11 +325,13 @@ class ImageRetrievalDaemon:
             if self.servers[0].name in ['LMSAL2']:
                 new_urls.append(extra_filtered)
                 if len(extra_filtered) > 0:
-                    self.oldest_timestamp = self._get_oldest_image(extra_filtered)
+                    # Using max(starttime, ...) so oldest_timestamp never goes earlier than the initial requested starttime
+                    self.oldest_timestamp = max(starttime, self._get_oldest_image(extra_filtered))
             else:
                 new_urls.append(filtered)
                 if len(filtered) > 0:
-                    self.oldest_timestamp = self._get_oldest_image(filtered)
+                    # Using max(starttime, ...) so oldest_timestamp never goes earlier than the initial requested starttime
+                    self.oldest_timestamp = max(starttime, self._get_oldest_image(filtered))
 
         # check disk space
         if not self.sent_diskspace_warning:

--- a/install/helioviewer/hvpull/servers/__init__.py
+++ b/install/helioviewer/hvpull/servers/__init__.py
@@ -68,6 +68,14 @@ class DataServer:
 
         return dates
 
+    def filter(self, file: str) -> bool:
+        """
+        Returns True if the file should be downloaded, otherwise False.
+        This may be overridden by specific Data Servers to only download
+        specific files from the upstream directory
+        """
+        return True
+
     def get_file_regex(self):
         """Returns a regex which described the expected format of filenames on
         the server"""

--- a/install/helioviewer/hvpull/servers/__init__.py
+++ b/install/helioviewer/hvpull/servers/__init__.py
@@ -76,11 +76,6 @@ class DataServer:
         """
         return True
 
-    def get_file_regex(self):
-        """Returns a regex which described the expected format of filenames on
-        the server"""
-        return self.filename_regex
-
     def get_measurements(self, nicknames, dates):
         """Get a list of all the URIs down to the measurement"""
         return None
@@ -93,7 +88,7 @@ class DataServer:
         return get_datetime_from_file(filename)
 
 
-class DataServerPauseDelayDefinesDefaultStartTime:
+class DataServerPauseDelayDefinesDefaultStartTime(DataServer):
     """Class for interacting with data servers. In this class the
     pause defines the default start time. If real time is UTC, then
     the default start time is UTC - pause minutes."""
@@ -133,11 +128,6 @@ class DataServerPauseDelayDefinesDefaultStartTime:
         dates.reverse()
 
         return dates
-
-    def get_file_regex(self):
-        """Returns a regex which described the expected format of filenames on
-        the server"""
-        return self.filename_regex
 
     def get_measurements(self, nicknames, dates):
         """Get a list of all the URIs down to the measurement"""

--- a/install/helioviewer/hvpull/servers/punch.py
+++ b/install/helioviewer/hvpull/servers/punch.py
@@ -24,3 +24,9 @@ class PUNCHDataServer(DataServer):
         fname = os.path.basename(filename)
         datestr = fname[13:27]
         return datetime.datetime.strptime(datestr, '%Y%m%d%H%M%S')
+
+    def filter(self, filename: str) -> bool:
+        """
+        PUNCH should only download the v0k files at this time.
+        """
+        return "v0k" in filename

--- a/install/helioviewer/hvpull/servers/punch.py
+++ b/install/helioviewer/hvpull/servers/punch.py
@@ -24,9 +24,3 @@ class PUNCHDataServer(DataServer):
         fname = os.path.basename(filename)
         datestr = fname[13:27]
         return datetime.datetime.strptime(datestr, '%Y%m%d%H%M%S')
-
-    def filter(self, filename: str) -> bool:
-        """
-        PUNCH should only download the v0k files at this time.
-        """
-        return "v0k" in filename


### PR DESCRIPTION
- Change Start Time logic so the next iteration always uses the Oldest file that was picked up, but never goes earlier than the given start time CLI arg. This helps for image sources that have a less standard release cadence. e.g. if downloader starts, and the last file it downloads is April 25, then it will continuously scan that same time until it gets more data instead of moving the search window forward.