### PR TITLE
Fix logging getJPX statistics

### DIFF
--- a/src/Database/Statistics.php
+++ b/src/Database/Statistics.php
@@ -129,13 +129,10 @@ class Database_Statistics {
                 $this->_dbConnection->link->real_escape_string($sourceId)
                );
         try {
-            echo $sql;
             $result = $this->_dbConnection->query($sql);
         }
         catch (Exception $e) {
             $this->_reportDatabaseError($e);
-            var_dump($e);
-            echo "DEAD";
             return false;
         }
 
@@ -167,6 +164,8 @@ class Database_Statistics {
             $redis->incr($key);
         }catch(Exception $e){
             //continue gracefully if redis statistics logging fails
+            Sentry::setTag('error_type', 'Redis Error');
+            Sentry::capture($e);
         }
     }
 

--- a/src/Database/Statistics.php
+++ b/src/Database/Statistics.php
@@ -17,10 +17,19 @@ require_once HV_ROOT_DIR . "/../src/Helper/ArrayExtensions.php";
 
 use DeviceDetector\ClientHints;
 use DeviceDetector\DeviceDetector;
+use Helioviewer\Api\Sentry\Sentry;
 
 class Database_Statistics {
 
     private $_dbConnection;
+
+    /**
+     * Report a database failure to Sentry tagged as "Database Error".
+     */
+    private function _reportDatabaseError(\Throwable $e): void {
+        Sentry::setTag('error_type', 'Database Error');
+        Sentry::capture($e);
+    }
 
     /**
      * Constructor
@@ -94,6 +103,7 @@ class Database_Statistics {
             $result = $this->_dbConnection->query($sql);
         }
         catch (Exception $e) {
+            $this->_reportDatabaseError($e);
             return false;
         }
 
@@ -124,6 +134,7 @@ class Database_Statistics {
             $result = $this->_dbConnection->query($sql);
         }
         catch (Exception $e) {
+            $this->_reportDatabaseError($e);
             return false;
         }
 
@@ -204,7 +215,7 @@ class Database_Statistics {
                 }
             }
             catch (Exception $e) {
-
+                $this->_reportDatabaseError($e);
             }
         }
 
@@ -253,7 +264,7 @@ class Database_Statistics {
                 }
             }
             catch (Exception $e) {
-
+                $this->_reportDatabaseError($e);
             }
         }
 
@@ -481,6 +492,7 @@ class Database_Statistics {
                 $result = $this->_dbConnection->query($sql);
             }
             catch (Exception $e) {
+                $this->_reportDatabaseError($e);
                 return false;
             }
 
@@ -526,6 +538,7 @@ class Database_Statistics {
                 $result = $this->_dbConnection->query($sql);
             }
             catch (Exception $e) {
+                $this->_reportDatabaseError($e);
                 return false;
             }
 
@@ -552,6 +565,7 @@ class Database_Statistics {
                 $result = $this->_dbConnection->query($sql);
             }
             catch (Exception $e) {
+                $this->_reportDatabaseError($e);
                 return false;
             }
 
@@ -600,6 +614,7 @@ class Database_Statistics {
                     $resultScreenshots = $this->_dbConnection->query($sqlScreenshots);
                 }
                 catch (Exception $e) {
+                    $this->_reportDatabaseError($e);
                     return false;
                 }
 
@@ -651,6 +666,7 @@ class Database_Statistics {
                     $resultScreenshots = $this->_dbConnection->query($sqlScreenshots);
                 }
                 catch (Exception $e) {
+                    $this->_reportDatabaseError($e);
                     return false;
                 }
 
@@ -718,6 +734,7 @@ class Database_Statistics {
             $result = $this->_dbConnection->query($sql);
         }
         catch (Exception $e) {
+            $this->_reportDatabaseError($e);
             return false;
         }
 

--- a/src/Database/Statistics.php
+++ b/src/Database/Statistics.php
@@ -121,8 +121,6 @@ class Database_Statistics {
         $sql = sprintf(
                   "INSERT INTO movies_jpx "
                 . "SET "
-                .     "id "        . " = NULL, "
-                .     "timestamp " . " = NULL, "
                 .     "reqStartDate " . " = '%s', "
                 .     "reqEndDate " . " = '%s', "
                 .     "sourceId " . " = %d;",
@@ -131,10 +129,13 @@ class Database_Statistics {
                 $this->_dbConnection->link->real_escape_string($sourceId)
                );
         try {
+            echo $sql;
             $result = $this->_dbConnection->query($sql);
         }
         catch (Exception $e) {
             $this->_reportDatabaseError($e);
+            var_dump($e);
+            echo "DEAD";
             return false;
         }
 


### PR DESCRIPTION
Issue is caused by strict mode enabled in MySQL.
Setting timestamp = NULL caused an error, instead of just using the default CURRENT_TIMESTAMP.
By leaving out timestamp and id altogether, the query succeeds.